### PR TITLE
build and publish from the same directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,11 @@
 #################
 ## Repo-specific
 #################
-src/shared/modules/badgeup-client/*.js
+src/shared/modules/badgeup-client/**/*.js
+src/shared/modules/badgeup-client/**/*.map
+src/shared/modules/badgeup-client/**/*.d.ts
+src/shared/modules/badgeup-client/**/*.ngsummary.json
+src/shared/modules/badgeup-client/badgeup-ionic-client.metadata.json
 
 #################
 ## Misc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ jobs:
       script:
         - cd src/shared/modules/badgeup-client
         - npm ci
-        - npm run package-module
+        - npm run build-module
+        - npm run check-module

--- a/src/shared/modules/badgeup-client/.npmignore
+++ b/src/shared/modules/badgeup-client/.npmignore
@@ -1,3 +1,11 @@
+# Node.js ecosystem files
+node_modules
+npm-debug.log
+
+# OS files
+Thumbs.db
+.DS_Store
+
 # ignore .ts files
 *.ts
 

--- a/src/shared/modules/badgeup-client/package.json
+++ b/src/shared/modules/badgeup-client/package.json
@@ -7,11 +7,9 @@
   "main": "badgeup-ionic-client.js",
   "typings": "badgeup-ionic-client.d.ts",
   "scripts": {
-    "package-module": "npm run clean-module && npm run copy-module && npm run build-module && npm run pack-module",
-    "clean-module": "rm -rf dist",
-    "copy-module": "rsync -a ./ dist/ --exclude=node_modules",
-    "build-module": "ngc --project dist/tsconfig.json --outDir dist",
-    "pack-module": "cd dist && npm pack && cd -"
+    "build-module": "ngc --project tsconfig.json --outDir .",
+    "check-module": "if [ ! -f badgeup-ionic-client.metadata.json ]; then echo 'metadata file not found'; exit 1; fi",
+    "prepublishOnly": "npm run build-module && npm run check-module"
   },
   "config": {
     "ionic_bundler": "webpack",

--- a/src/shared/modules/badgeup-client/tsconfig.json
+++ b/src/shared/modules/badgeup-client/tsconfig.json
@@ -13,7 +13,7 @@
       "moduleResolution": "node",
       "sourceMap": true,
       "stripInternal": true,
-      "outDir": "dist",
+      "outDir": ".",
       "rootDir": ".",
       "types": [
         "@types/p-map",


### PR DESCRIPTION
do all the `npm publish` work from the module directory instead of a dedicated `dist` directory in order to make publishing a sane process